### PR TITLE
Search button centered relative to the page

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -67,6 +67,8 @@ body.no-scroll {
 .nav-links.center {
   justify-content: center;
   align-items: center;
+
+  padding-right: 12%;
 }
 
 /* TODO: Display the search input box on hovering the search text ✨ */


### PR DESCRIPTION
fixes #1 

- centered the search button relative to the page, using percentage padding
- page is also responsive, as uploaded in the 2nd screenshot
![Screenshot_20230205_001419](https://user-images.githubusercontent.com/11803841/216784382-50f67da8-b24d-498b-8f7f-edf24cd6c626.png)
![Screenshot_20230205_001443](https://user-images.githubusercontent.com/11803841/216784384-79a78c77-832c-4588-a3a3-27bf2a491d46.png)
