### PR TITLE
Added the favicon to the webpage fixed#5

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="public\fonts\SFProDisplay\stylesheet.css" />
     <link rel="stylesheet" href="styles/global.css" />
     <link rel="stylesheet" href="styles/reset.css" />
+    <link rel="shortcut icon" href="./public/favicon.ico" type="image/x-icon">
   </head>
   <body>
     <div id="backdrop" class="hidden fadeout" tabindex="0"></div>


### PR DESCRIPTION
fixed issue #5 : Added a favicon

- Used the link tag to link to the `favicon.ico` file which was in `./public` directory.
- Now the favicon is clearly visible beside title text.

## Following is the attached photo of the solved issue.

![Screenshot_20230206_111742](https://user-images.githubusercontent.com/11803841/216893346-abdca371-77e3-4b44-9acb-d21c561720f0.png)
