### PR TITLE
fixed #8 - Disabled body scroll when dialog open, then it gets opened

### DIFF
--- a/scripts/Dialog.js
+++ b/scripts/Dialog.js
@@ -16,6 +16,9 @@ export default class Dialog {
     dialogCloseBtn.innerHTML = "&times;";
     dialogCloseBtn.onclick = () => {
       dialogEl.close();
+
+      // enable body scrolling as soon as the dialog closes
+      enableBodyScroll();
     };
     dialogEl.appendChild(dialogCloseBtn);
     dialogEl.appendChild(dialogContent);
@@ -64,6 +67,8 @@ export default class Dialog {
   toggleDialog() {
     if (this.#dialogElement.open) this.#dialogElement.close();
     else this.#dialogElement.showModal();
+    enableBodyScroll();
+
   }
 
   /**
@@ -75,4 +80,11 @@ export default class Dialog {
     this.#dialogContent.appendChild(DOMNode);
     return this;
   }
+}
+
+
+// To enable body scrolling when the dialog box closes
+function enableBodyScroll() {
+  let bodyElement = document.querySelector('body');
+  bodyElement.style.overflow = 'auto';
 }

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -69,6 +69,9 @@ async function searchUsingAPI() {
         console.log({ data });
         mainMovieDialog.replaceContent(Generator.generateMainCard(data));
         mainMovieDialog.showDialog();
+
+        // disable body scrolling when the dialog opens
+        disableBodyScroll();
       })
     );
   });
@@ -106,3 +109,12 @@ function disableBackdrop() {
   backdrop.classList.replace("fadein", "fadeout");
   document.body.classList.remove("no-scroll");
 }
+
+
+
+// Added function to disable body scrolling when the dialog opens
+function disableBodyScroll() {
+  let bodyElement = document.querySelector('body');
+  bodyElement.style.overflow = 'hidden';
+}
+

--- a/styles/global.css
+++ b/styles/global.css
@@ -556,8 +556,13 @@ img.dark {
   border: none;
   border-radius: var(--border-radius);
   box-shadow: var(--btn-box-shadow);
-  position: relative;
+
+  /* to prevent dialog box jumping when body overflow:hidden */
+  position: fixed;
+
   max-width: 80%;
+
+
 }
 
 .dialog::backdrop {


### PR DESCRIPTION
fixed #8 : Scroll Disabled when dialog open
---
- Created 2 JavaScript functions, `disableBodyScroll()` and `enableBodyScroll()`.
- Scroll gets disabled when the dialog opens.
- Scroll gets enabled when the dialog closes.

- I have achieved this by utilising the `overflow:hidden` property of the `body` element.
---
## Following are the screenshots after solving the issue

> Scroll Disabled
![Screenshot_20230206_140917](https://user-images.githubusercontent.com/11803841/216925615-1dfcdf6b-6611-41e8-8b35-aaa4a4eccf07.png)

> Scroll Enabled
![Screenshot_20230206_141004](https://user-images.githubusercontent.com/11803841/216925853-5d80fc84-456e-4491-aef9-c74a6e04fb94.png)
