### PR TITLE
fixed #2 Random whitespace btwn image and info div solved

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -497,6 +497,18 @@ section.results.hidden {
   border-radius: var(--border-radius);
 }
 
+/* ----------------------------------------------------------------------------- */
+
+/*! REMOVING WHITESPACE BETWEEN ELEMENTS */
+
+.overflow-info h2 {
+  margin: calc(1% - 2px);
+}
+
+
+/* ----------------------------------------------------------------------------- */
+
+
 .vinyl-info:hover .overflow-info {
   transform: translateY(
     calc(


### PR DESCRIPTION
fixed issue #2 

- There was some gap between the **image** and the **movie info**, I have fixed it by changing the margin of the **info heading**
- Using the mathematical computation `margin: calc(1%-2px)` which leaves a minute gap so that it still looks good and not stuck with the image.

## Following is the attached image of the solved issue.

![Screenshot_20230206_163444](https://user-images.githubusercontent.com/11803841/216956549-1207ffcc-dde2-49fd-ac73-801c1ee2d8fd.png)
