### PR TITLE
cleared previous search results fixed #14

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -35,6 +35,15 @@ searchSpan.addEventListener("click", () => openSearchForm());
 
 searchBtn.addEventListener("click", searchUsingAPI);
 
+
+searchBtn.addEventListener('click', clearPreviousResults);
+
+
+function clearPreviousResults() {
+  searchResults.innerHTML = "";
+}
+
+
 function onLoseFocus(e) {
   if (e.target == backdrop) {
     closeSearchForm();
@@ -73,6 +82,7 @@ async function searchUsingAPI() {
     );
   });
   resultsSection.classList.remove("hidden");
+
 }
 
 function openSearchForm() {


### PR DESCRIPTION
cleared previous search results fixed #14

- Previous search results were accumulated after the next search.
- Fixed the issue by creating and calling a JS `clearPreviousResults()` function.
- It gets called every time `Search` button is pressed.

---
### following are the screenshots of the fixed issue
---
![Screenshot_20230206_235249](https://user-images.githubusercontent.com/11803841/217054002-ac3683b9-f363-4ff6-8533-99b306b634ff.png)
![Screenshot_20230206_235307](https://user-images.githubusercontent.com/11803841/217054014-2e42a99d-350d-4473-b2aa-bb2f6f0de482.png)

![Screenshot_20230206_235230](https://user-images.githubusercontent.com/11803841/217053995-46b61904-d95a-4d22-97b7-ff908dae0fee.png)


